### PR TITLE
highlight current color, only on entering edit mode

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -198,6 +198,11 @@ View.prototype = {
         var modaltitle = $('#modal-note-div #title-editable');
         var modalcontent = $('#modal-note-dive #content-editable');
         var modalnote = $("#modal-note-div .quicknote");
+        //remove checkmark icons from temp selected color
+        var modalcolortools = $("#modal-note-div .circle-toolbar");
+        $.each(modalcolortools, function(i, colortool) {
+            $(colortool).removeClass('icon-checkmark');
+        });
 
         this._notes.unsetActive();
 
@@ -306,6 +311,11 @@ View.prototype = {
         $('#app-content .circle-toolbar').click(function (event) {
             event.stopPropagation();
 
+            var oldColorTool = $('.circle-toolbar.icon-checkmark');
+            $.each(oldColorTool, function(i, oct) {
+               $(oct).removeClass('icon-checkmark'); 
+            });
+            $(this).addClass('icon-checkmark');
             var color = $(this).css("background-color");
             modalnote.css("background-color", color);
         });

--- a/js/script.js
+++ b/js/script.js
@@ -163,6 +163,12 @@ View.prototype = {
         var title = note.find("#title-editable").html();
         var content = note.find("#content-editable").html();
         var color = note.children().css("background-color");
+        var colors = modal[0].getElementsByClassName("circle-toolbar");
+        $.each(colors, function(i, c) {
+            if(color == c.style.backgroundColor) {
+                c.className += " icon-checkmark";
+            }
+        });
 
         var modalid = modalnote.data('id');
 


### PR DESCRIPTION
This PR highlights the current note color. But only if the user enters the edit mode. If the users switches between colors without clicking on "Save" and re-enter the edit mode the highlight will not be updated. I'll add some more commits (or you can add them^^) to this if the general idea is ok for you :wink: 