### PR TITLE
show user labels in share dialog

### DIFF
--- a/js/qn-dialogs.js
+++ b/js/qn-dialogs.js
@@ -159,7 +159,7 @@ const QnDialogs = {
 					var data = [];
 					availableUsers.forEach(function (item, index) {
 						// Select2 expect id, text.
-						data.push({id: item, text: item});
+						data.push({id: item[0], text: item[1]});
 					});
 					return data;
 				},

--- a/js/script.js
+++ b/js/script.js
@@ -169,10 +169,10 @@ Notes.prototype = {
         }).done(function (shares) {
             var users = [];
             $.each(shares.ocs.data.exact.users, function(index, user) {
-                users.push(user.value.shareWith);
+                users.push([user.value.shareWith, user.label]);
             });
             $.each(shares.ocs.data.users, function(index, user) {
-                users.push(user.value.shareWith);
+                users.push([user.value.shareWith, user.label]);
             });
             self._usersSharing = users;
         }).fail(function () {


### PR DESCRIPTION
this change makes possible to display users' names instead of IDs in share dialog even if LDAP / AD integration is enabled.

Fixes #49 